### PR TITLE
Fix zip extraction creating files as directories (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -302,4 +302,4 @@ __pycache__/
 *.xsd.cs
 
 # OpenCover UI analysis results
-OpenCover/
+OpenCover/_codeql_detected_source_root


### PR DESCRIPTION
* Initial plan

* Fix zip extraction creating files as directories instead of extracting them

When extracting files from a zip archive, if the parent directory of a file didn't exist, the code was calling create_directories(fullPath) which created the full path including the filename as a directory. Additionally, the file.extract() call was inside an else block, so it was never executed when the parent folder didn't exist.

Fixed by:
1. Changed create_directories(fullPath) to create_directories(fullPath.parent_path()) to only create the parent directory
2. Moved file extraction outside the else block so it always executes



* Remove accidentally committed CodeQL symlink



---------